### PR TITLE
rutas y queries de filtros terminadas

### DIFF
--- a/src/routes/ares.routes.js
+++ b/src/routes/ares.routes.js
@@ -13,16 +13,7 @@ areaRoutes.get('/', async (req, res) => {
       return res.status(500).json({ data: error.message });
     }
   })
-areaRoutes.get('/professional/:area', async (req, res) => {
-  const {area} = req.params;
-    try {
-      const data = await findAllProfessionalWithArea(area);
-      if (!data) return res.status(400).json("Base de datos vacia");
-      return res.status(200).json(data);
-    } catch (error) {
-      return res.status(500).json({ data: error.message });
-    }
-  })
+
 
   
 

--- a/src/routes/professional.routes.js
+++ b/src/routes/professional.routes.js
@@ -6,11 +6,12 @@ import userJWTDTO from "../helpers/checkTKN.js";
 import { generatorTKN } from "../helpers/generatorTKN.js";
 import {
     createProfessionalUser,
+    findAllProfessionalWithArea,
     findAllProfessional,
     getProfessionalByDNI,
     getProfessionalByEmail,
     getProfessionalById,
-    findAllProfessionalByNames
+    findAllProfessionalByAreaAndNames
 } from "../query/queryToPsico.js";
 
 const professionalRoutes = Router();
@@ -20,7 +21,21 @@ professionalRoutes.get("/", async (req, res) => {
     try {
       let data;
       if(!name && !lastName) data = await findAllProfessional();
-      else data = await findAllProfessionalByNames(name,lastName);
+      else data=await findAllProfessionalByAreaAndNames(null,name,lastName);  
+      if (!data) return res.status(400).json("Base de datos vacia");
+      return res.status(200).json(data);
+    } catch (error) {
+      return res.status(500).json({ data: error.message });
+    }
+  });
+
+professionalRoutes.get("/:area", async (req, res) => {
+  const { name, lastName } = req.query;
+  const {area} = req.params;
+    try {
+      let data;
+     if(!name && !lastName) data= await findAllProfessionalWithArea(area)
+      else data=await findAllProfessionalByAreaAndNames(area,name,lastName);     
       if (!data) return res.status(400).json("Base de datos vacia");
       return res.status(200).json(data);
     } catch (error) {

--- a/src/testing/profesional.js
+++ b/src/testing/profesional.js
@@ -13,6 +13,14 @@ const user = [
     area:'Depresion'
   },
   {
+    email: "valdez31@asd.com",
+    name: "doctorchapatin",
+    lastName: "Valdez",
+    password: "Test1274",
+    DNI:"12345770",
+    area:'Depresion'
+  },
+  {
     email: "valdez1@asd.com",
     name: "doctorchapatin",
     lastName: "Valdez",


### PR DESCRIPTION
Modifiqué las rutas '/professional', donde hay una ruta '/' que busca a todos los profesionales(sin filtros) con posibilidad de agregarse queries (filtro por nombre/apellido), y otra ruta '/:area' que recibe area por params (filtro por area) con posibilidad de agregarse las mismas queries mencionadas anteriormente. A su vez, las queries empleadas son: 
'findAllProfessionalWithArea': busca profesionales por area,
'findAllProfessional': busca todos los profesionales,
'findAllProfessionalByAreaAndNames': en caso de pasarle area, busca profesionales por area y nombre/apellido; en caso de no recibir area, busca solo por nombre/apellido.
Sorry por el testamento, byeeee